### PR TITLE
Fix partial matching in seq()

### DIFF
--- a/R/palletes.R
+++ b/R/palletes.R
@@ -36,7 +36,7 @@ user_colours <- function(n, i){
 
 
 gg_color_hue <- function(n) {
-  hues = seq(15, 375, length = n + 1)
+  hues = seq(15, 375, length.out = n + 1)
   hcl(h = hues, l = 65, c = 100)[1:n]
 }
 


### PR DESCRIPTION
I think it would be better to avoid partial matching in function call.

It helps to suppress annoying message for users who set warning on partial matching.